### PR TITLE
[bugfix/wf-109] refresh logic and its guard

### DIFF
--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -19,7 +19,7 @@ import { TokensDto } from 'src/tokens/dto/tokens.dto';
 import { AuthResponseDto, LoginUserDto, RegisterUserOwnerDto, UserSessionDto } from './dto';
 import { CreateCompanyDto } from 'src/companies/dto';
 import { EMAIL_PASSWORD_INCORRECT, NO_SESSION, UNAUTHORIZED, USER_EXISTS } from '@constants/error';
-import { csrfAndRefreshTokenGuard } from 'src/common/guards';
+import { RefreshTokenGuard } from 'src/common/guards';
 
 @ApiTags('auth')
 @Controller('auth')
@@ -89,17 +89,15 @@ export class AuthController {
   }
 
   @Public()
-  @UseGuards(csrfAndRefreshTokenGuard)
+  @UseGuards(RefreshTokenGuard)
   @Get('refresh')
-  @ApiSecurity('csrf')
   @ApiBearerAuth('refresh')
   @ApiOkResponse({ description: 'The tokens has been successfully refreshed.', type: AuthResponseDto })
   @ApiUnauthorizedResponse({ description: 'Unauthorized by refresh token.' })
   async refresh(@Req() req: Request, @Res() res: Response): Promise<Response<AuthResponseDto>> {
     const { refreshToken } = req.cookies;
-    const csrfToken = this.tokensService.getCsrfTokenFromRequest(req);
 
-    const userData = await this.authService.refresh(refreshToken, csrfToken);
+    const userData = await this.authService.refresh(refreshToken);
 
     this.setCookies(res, userData.tokens);
 

--- a/src/auth/auth.service.ts
+++ b/src/auth/auth.service.ts
@@ -72,17 +72,14 @@ export class AuthService {
     await this.tokensService.nullCSRFToken(csrfToken);
   }
 
-  async refresh(refreshToken: string, csrfToken: string): Promise<UserReturnDto> {
-    if (!refreshToken || !csrfToken) {
+  async refresh(refreshToken: string): Promise<UserReturnDto> {
+    if (!refreshToken) {
       throw new UnauthorizedException();
     }
 
     const userRefreshData = this.tokensService.validateRefreshToken(refreshToken);
     const refreshTokenFromDb = await this.tokensService.findRefreshToken(refreshToken);
-    const userCSRFData = this.tokensService.validateCSRFToken(csrfToken);
-    const csrfTokenFromDb = await this.tokensService.findCSRFToken(csrfToken);
-
-    if (!userRefreshData || !refreshTokenFromDb || !userCSRFData || !csrfTokenFromDb) {
+    if (!userRefreshData || !refreshTokenFromDb) {
       throw new UnauthorizedException();
     }
 

--- a/src/common/guards/index.ts
+++ b/src/common/guards/index.ts
@@ -1,2 +1,2 @@
-export { csrfAndRefreshTokenGuard } from './csrfAndRefreshToken.guard';
+export { RefreshTokenGuard } from './refreshToken.guard';
 export { CsrfAndAccessTokenGuard } from './csrfAndAccessToken.guard';

--- a/src/common/guards/refreshToken.guard.ts
+++ b/src/common/guards/refreshToken.guard.ts
@@ -2,15 +2,11 @@ import { CanActivate, ExecutionContext, Injectable, UnauthorizedException } from
 import { TokensService } from 'src/tokens/tokens.service';
 
 @Injectable()
-export class csrfAndRefreshTokenGuard implements CanActivate {
+export class RefreshTokenGuard implements CanActivate {
   constructor(private tokensService: TokensService) {}
 
   canActivate(context: ExecutionContext): boolean {
     const request = context.switchToHttp().getRequest();
-
-    const token = this.tokensService.getCsrfTokenFromRequest(request);
-    this.tokensService.validateCSRFToken(token);
-
     const { refreshToken } = request.cookies;
     if (!refreshToken) {
       throw new UnauthorizedException();


### PR DESCRIPTION
Refresh endpoint - auth/refresh was waiting for 2 tokens: csrfToken and refreshToken, when request executes also for giving csrfToken (when it expires) => 401 error and redirect on client side. 